### PR TITLE
Fix typo in Fibonacci example

### DIFF
--- a/src/textbooks/techniques-in-computer-science/variables/Chapter.md
+++ b/src/textbooks/techniques-in-computer-science/variables/Chapter.md
@@ -425,7 +425,7 @@ Now we can proceed to calculate the remaining Fibonacci numbers, according to th
 >>> fib_11 = fib_10 + fib_9
 >>> fib_12 = fib_11 + fib_10
 >>> fib_13 = fib_12 + fib_11
->>> fib_14 = fib_13 + fib_13
+>>> fib_14 = fib_13 + fib_12
 >>> fib_14
 377
 ```


### PR DESCRIPTION
The line for computing fib_14 in the code snippet uses fib_13 twice:

```
>>> fib_14 = fib_13 + fib_13
>>> fib_14
377
```

While the result shown for fib_14 is correct (377), going by the
above, the result of fib_14 would be 466 instead.

This line should instead be:

```
>>> fib_14 = fib_13 + fib_12